### PR TITLE
Upgrade provisio to 1.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <mavenVersion>3.2.3</mavenVersion>
         <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
-        <provisioVersion>1.0.7</provisioVersion>
+        <provisioVersion>1.0.16</provisioVersion>
         <takari.javaSourceVersion>1.8</takari.javaSourceVersion>
 
         <!-- declare language version for IntelliJ IDEA -->

--- a/src/main/resources-filtered/META-INF/plexus/components.xml
+++ b/src/main/resources-filtered/META-INF/plexus/components.xml
@@ -45,7 +45,7 @@
                             </test>
                             <package>
                                 org.apache.maven.plugins:maven-jar-plugin:2.4:jar,
-                                ca.vanzyl.maven.plugins:provisio-maven-plugin:${provisioVersion}:provision
+                                ca.vanzyl.provisio.maven.plugins:provisio-maven-plugin:${provisioVersion}:provision
                             </package>
                             <install>
                                 org.apache.maven.plugins:maven-install-plugin:2.4:install


### PR DESCRIPTION
This allows building and packaging using JDK 16 by upgrading to use a version of XStream that works with JDK 16.

See https://github.com/trinodb/trino/issues/7901 for more details.