### PR TITLE
Switch to units library for test projects

### DIFF
--- a/src/test/java/io/trino/maven/TestCheckerIntegration.java
+++ b/src/test/java/io/trino/maven/TestCheckerIntegration.java
@@ -46,8 +46,7 @@ class TestCheckerIntegration {
         File basedir = resources.getBasedir("invalid-extra");
         maven.forProject(basedir)
                 .execute("verify")
-                .assertLogText(
-                        "[ERROR] Trino plugin dependency com.google.guava:guava must not have scope 'provided'.");
+                .assertLogText("[ERROR] Trino plugin dependency io.airlift:units must not have scope 'provided'.");
     }
 
     @MavenPluginTest
@@ -67,7 +66,7 @@ class TestCheckerIntegration {
         File basedir = resources.getBasedir("invalid-and-excluded-extra");
         maven.forProject(basedir)
                 .execute("verify")
-                .assertNoLogText("dependency com.google.guava:guava must")
+                .assertNoLogText("dependency io.airlift:units must")
                 .assertLogText(
                         "[ERROR] Trino plugin dependency org.scala-lang:scala-library must not have scope 'provided'.");
     }

--- a/src/test/projects/excluded-extra/pom.xml
+++ b/src/test/projects/excluded-extra/pom.xml
@@ -14,9 +14,9 @@
     <dependencies>
         <!-- this dependency is not part of the SPI; it can be provided because it's individually excluded from the check -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <version>1.13</version>
             <scope>provided</scope>
         </dependency>
 
@@ -37,7 +37,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <allowedProvidedDependencies>
-                        <allowedProvidedDependency>com.google.guava:guava</allowedProvidedDependency>
+                        <allowedProvidedDependency>io.airlift:units</allowedProvidedDependency>
                     </allowedProvidedDependencies>
                 </configuration>
             </plugin>

--- a/src/test/projects/invalid-and-excluded-extra/pom.xml
+++ b/src/test/projects/invalid-and-excluded-extra/pom.xml
@@ -14,9 +14,9 @@
     <dependencies>
         <!-- this dependency is not part of the SPI; it can be provided because it's individually excluded from the check -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <version>1.13</version>
             <scope>provided</scope>
         </dependency>
 
@@ -45,7 +45,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <allowedProvidedDependencies>
-                        <allowedProvidedDependency>com.google.guava:guava</allowedProvidedDependency>
+                        <allowedProvidedDependency>io.airlift:units</allowedProvidedDependency>
                     </allowedProvidedDependencies>
                 </configuration>
             </plugin>

--- a/src/test/projects/invalid-extra/pom.xml
+++ b/src/test/projects/invalid-extra/pom.xml
@@ -14,9 +14,9 @@
     <dependencies>
         <!-- this dependency is not part of the SPI and thus should not be provided -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <version>1.13</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/projects/invalid-skipped/pom.xml
+++ b/src/test/projects/invalid-skipped/pom.xml
@@ -14,9 +14,9 @@
     <dependencies>
         <!-- this dependency is not part of the SPI and thus should not be provided -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <version>1.13</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/projects/two-excluded-extra/pom.xml
+++ b/src/test/projects/two-excluded-extra/pom.xml
@@ -14,9 +14,9 @@
     <dependencies>
         <!-- this dependency is not part of the SPI; it can be provided because it's individually excluded from the check -->
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <version>1.13</version>
             <scope>provided</scope>
         </dependency>
 
@@ -45,7 +45,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <allowedProvidedDependencies>
-                        <allowedProvidedDependency>com.google.guava:guava</allowedProvidedDependency>
+                        <allowedProvidedDependency>io.airlift:units</allowedProvidedDependency>
                         <allowedProvidedDependency>org.scala-lang:scala-library</allowedProvidedDependency>
                     </allowedProvidedDependencies>
                 </configuration>


### PR DESCRIPTION
This avoids security warnings for using outdated Guava versions and is a simpler library with no transitive dependencies.