### PR TITLE
Allow JTS as a built-in provided dependency for Trino plugins

### DIFF
--- a/src/main/java/io/trino/maven/SpiDependencyChecker.java
+++ b/src/main/java/io/trino/maven/SpiDependencyChecker.java
@@ -30,6 +30,8 @@ import org.eclipse.aether.graph.DependencyNode;
         requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
         threadSafe = true)
 public class SpiDependencyChecker extends AbstractMojo {
+    private static final Set<String> BUILT_IN_ALLOWED_PROVIDED_DEPENDENCIES = Set.of("org.locationtech.jts:jts-core");
+
     @Parameter(defaultValue = "io.trino")
     private String spiGroupId;
 
@@ -82,7 +84,7 @@ public class SpiDependencyChecker extends AbstractMojo {
                 throw new MojoExecutionException(format(
                         "%n%nTrino plugin dependency %s must have scope 'test'. It must not be on the plugin classpath.",
                         name));
-            } else if ("provided".equals(artifact.getScope()) && !allowedProvidedDependencies.contains(name)) {
+            } else if ("provided".equals(artifact.getScope()) && !isAllowedProvidedDependency(name)) {
                 throw new MojoExecutionException(format(
                         "%n%nTrino plugin dependency %s must not have scope 'provided'. It is not part of the SPI and will not be available at runtime.",
                         name));
@@ -120,6 +122,10 @@ public class SpiDependencyChecker extends AbstractMojo {
             }
         }
         throw new MojoExecutionException(format("%n%nTrino plugin must depend on %s.", spiName()));
+    }
+
+    private boolean isAllowedProvidedDependency(String name) {
+        return BUILT_IN_ALLOWED_PROVIDED_DEPENDENCIES.contains(name) || allowedProvidedDependencies.contains(name);
     }
 
     private boolean isSpiArtifact(Artifact artifact) {

--- a/src/test/java/io/trino/maven/TestCheckerIntegration.java
+++ b/src/test/java/io/trino/maven/TestCheckerIntegration.java
@@ -50,6 +50,12 @@ class TestCheckerIntegration {
     }
 
     @MavenPluginTest
+    void testBuiltInAllowedExtraProvided() throws Exception {
+        File basedir = resources.getBasedir("built-in-allowed-extra");
+        maven.forProject(basedir).execute("verify").assertErrorFreeLog();
+    }
+
+    @MavenPluginTest
     void testExcludedExtraProvided() throws Exception {
         File basedir = resources.getBasedir("excluded-extra");
         maven.forProject(basedir).execute("verify").assertErrorFreeLog();

--- a/src/test/projects/built-in-allowed-extra/pom.xml
+++ b/src/test/projects/built-in-allowed-extra/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.trino.maven.its</groupId>
+    <artifactId>built-in-allowed-extra</artifactId>
+    <version>1.0</version>
+    <packaging>trino-plugin</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>1.18.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <version>351</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-maven-plugin</artifactId>
+                <version>${it-plugin.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/projects/built-in-allowed-extra/src/main/java/its/ValidPlugin.java
+++ b/src/test/projects/built-in-allowed-extra/src/main/java/its/ValidPlugin.java
@@ -1,0 +1,7 @@
+package its;
+
+import io.trino.spi.Plugin;
+
+public class ValidPlugin
+        implements Plugin
+{}


### PR DESCRIPTION
Trino now exposes JTS through the plugin class loader, so plugin authors need a stable way to declare `org.locationtech.jts:jts-core` as `provided` without every repo overriding the plugin configration separately.
