### PR TITLE
Install the classes jar alongside the plugin bundle

### DIFF
--- a/src/main/java/io/trino/maven/TrinoPluginPackager.java
+++ b/src/main/java/io/trino/maven/TrinoPluginPackager.java
@@ -6,6 +6,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProjectHelper;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.graph.Dependency;
@@ -14,6 +15,8 @@ import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
 import org.eclipse.aether.util.filter.ScopeDependencyFilter;
+
+import javax.inject.Inject;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -67,6 +70,9 @@ public class TrinoPluginPackager
     @Parameter(property = "skipPackageTrinoPlugin", defaultValue = "false")
     private boolean skipPackageTrinoPlugin;
 
+    @Inject
+    private MavenProjectHelper projectHelper;
+
     @Override
     public void execute()
             throws MojoExecutionException
@@ -78,6 +84,7 @@ public class TrinoPluginPackager
 
         String prefix = project.getArtifactId() + "-" + project.getVersion() + "/";
         Optional<FileTime> timestamp = parseOutputTimestamp(outputTimestamp);
+        File projectJar = project.getArtifact().getFile();
         writeBundle(collectBundleEntries(prefix), timestamp);
 
         // Set the timestamp on the archive file itself for reproducible builds
@@ -89,6 +96,11 @@ public class TrinoPluginPackager
                 throw new MojoExecutionException("Failed to set timestamp on plugin zip.", e);
             }
         }
+
+        // The trino-plugin artifact handler uses the zip extension, so the main artifact is the plugin bundle. Attach
+        // the classes jar as an additional artifact so it is installed and deployed too: plugin modules are legitimately
+        // compile dependencies (with the default jar type) of other modules.
+        projectHelper.attachArtifact(project, "jar", projectJar);
 
         project.getArtifact().setFile(outputFile);
         if (getLog().isInfoEnabled()) {

--- a/src/test/java/io/trino/maven/TestGeneratorIntegration.java
+++ b/src/test/java/io/trino/maven/TestGeneratorIntegration.java
@@ -1,5 +1,6 @@
 package io.trino.maven;
 
+import io.takari.maven.testing.TestProperties;
 import io.takari.maven.testing.TestResources5;
 import io.takari.maven.testing.executor.MavenRuntime;
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
@@ -8,16 +9,22 @@ import io.takari.maven.testing.executor.junit.MavenPluginTest;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.delete;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.walk;
 import static java.util.Collections.list;
+import static java.util.Collections.reverseOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.codehaus.plexus.util.IOUtil.toByteArray;
 
@@ -98,6 +105,37 @@ class TestGeneratorIntegration
                     .extracting(ZipEntry::getName)
                     .contains("pom-type-dependency-1.0/pom-type-dependency-1.0.jar")
                     .noneMatch(name -> name.endsWith(".pom"));
+        }
+    }
+
+    @MavenPluginTest
+    void testClassesJarIsInstalledAlongsideBundle()
+            throws Exception
+    {
+        // The trino-plugin artifact handler uses the zip extension, so the main artifact installs as the plugin
+        // bundle. The classes jar must be installed as well, because plugin modules are compile dependencies (with
+        // the default jar type) of other modules.
+        File basedir = resources.getBasedir("basic");
+        Path installDirectory = new TestProperties().getLocalRepository().toPath()
+                .resolve("io/trino/maven/its/basic/1.0");
+        deleteRecursively(installDirectory);
+
+        maven.forProject(basedir).execute("install").assertErrorFreeLog();
+
+        assertThat(installDirectory.resolve("basic-1.0.zip")).isRegularFile();
+        assertThat(installDirectory.resolve("basic-1.0.jar")).isRegularFile();
+    }
+
+    private static void deleteRecursively(Path directory)
+            throws IOException
+    {
+        if (!exists(directory)) {
+            return;
+        }
+        try (Stream<Path> paths = walk(directory)) {
+            for (Path path : paths.sorted(reverseOrder()).toList()) {
+                delete(path);
+            }
         }
     }
 


### PR DESCRIPTION
The trino-plugin artifact handler uses the zip extension, so the main artifact is the plugin bundle. Since the rewrite to a programmatic model, package-trino-plugin only pointed the main artifact at the zip, so the jar built by maven-jar-plugin was never installed or deployed. Modules with a plain compile dependency on a trino-plugin module then failed to resolve it, for example plugin/trino-exchange-hdfs on plugin/trino-exchange-filesystem in the Trino tree.

Provisio, which this replaced, attached the jar as an additional artifact for non-jar packaging before swapping the main artifact to the archive. Restore that: attach the jar so both artifacts are published.