### PR TITLE
Make plugin bundle compression configurable

### DIFF
--- a/src/main/java/io/trino/maven/TrinoPluginPackager.java
+++ b/src/main/java/io/trino/maven/TrinoPluginPackager.java
@@ -70,6 +70,15 @@ public class TrinoPluginPackager
     @Parameter(property = "skipPackageTrinoPlugin", defaultValue = "false")
     private boolean skipPackageTrinoPlugin;
 
+    /**
+     * Whether to deflate the bundle entries. Off by default: the bundled jars are themselves compressed archives, so
+     * deflating them again only recovers the parts that are not, namely their central directories, {@code META-INF}
+     * text and any entries the jar itself stored verbatim. That is worth roughly a tenth of the bundle, paid for with
+     * compression time on every build. Enable it to trade a slower package phase for smaller bundles.
+     */
+    @Parameter(property = "trino.plugin.compressed", defaultValue = "false")
+    private boolean compress;
+
     @Inject
     private MavenProjectHelper projectHelper;
 
@@ -167,9 +176,9 @@ public class TrinoPluginPackager
     {
         try (OutputStream out = new BufferedOutputStream(newOutputStream(outputFile.toPath()));
                 ZipOutputStream zip = new ZipOutputStream(out)) {
-            zip.setMethod(ZipOutputStream.STORED);
+            zip.setMethod(compress ? ZipOutputStream.DEFLATED : ZipOutputStream.STORED);
             for (Entry<String, Path> file : filesToAdd) {
-                zip.putNextEntry(storedEntry(file.getKey(), file.getValue(), timestamp));
+                zip.putNextEntry(bundleEntry(file.getKey(), file.getValue(), timestamp));
                 copy(file.getValue(), zip);
                 zip.closeEntry();
             }
@@ -229,21 +238,25 @@ public class TrinoPluginPackager
     }
 
     /**
-     * Builds a {@code STORED} (uncompressed) entry. The zip format requires the size and CRC of a stored entry to be
-     * known before its data is written, so the file is streamed once here to checksum it and once again by the caller
-     * to copy it. Streaming twice keeps memory flat no matter how large the bundle is; the jars are already compressed,
-     * so storing them verbatim avoids pointlessly recompressing them.
+     * Builds the entry header. A {@code DEFLATED} entry needs nothing up front, because {@link ZipOutputStream} sizes
+     * and checksums it while the data streams through. A {@code STORED} entry does: the zip format requires its size
+     * and CRC before its data is written, so the file is streamed once here to checksum it and once again by the caller
+     * to copy it. Streaming twice keeps memory flat no matter how large the bundle is.
      */
-    private static ZipEntry storedEntry(String entryName, Path file, Optional<FileTime> fileTime)
+    private ZipEntry bundleEntry(String entryName, Path file, Optional<FileTime> fileTime)
             throws IOException
     {
-        long fileSize = size(file);
         ZipEntry entry = new ZipEntry(entryName);
+        fileTime.ifPresent(entry::setLastModifiedTime);
+        if (compress) {
+            entry.setMethod(ZipEntry.DEFLATED);
+            return entry;
+        }
+        long fileSize = size(file);
         entry.setMethod(ZipEntry.STORED);
         entry.setSize(fileSize);
         entry.setCompressedSize(fileSize);
         entry.setCrc(checksum(file));
-        fileTime.ifPresent(entry::setLastModifiedTime);
         return entry;
     }
 

--- a/src/test/java/io/trino/maven/TestGeneratorIntegration.java
+++ b/src/test/java/io/trino/maven/TestGeneratorIntegration.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Stream;
@@ -124,6 +125,38 @@ class TestGeneratorIntegration
 
         assertThat(installDirectory.resolve("basic-1.0.zip")).isRegularFile();
         assertThat(installDirectory.resolve("basic-1.0.jar")).isRegularFile();
+    }
+
+    @MavenPluginTest
+    void testBundleIsStoredByDefault()
+            throws Exception
+    {
+        File basedir = resources.getBasedir("basic");
+        maven.forProject(basedir).execute("package").assertErrorFreeLog();
+
+        assertThat(bundleEntryMethods(basedir, "basic")).containsOnly(ZipEntry.STORED);
+    }
+
+    @MavenPluginTest
+    void testBundleCompressionCanBeEnabled()
+            throws Exception
+    {
+        File basedir = resources.getBasedir("basic");
+        maven.forProject(basedir)
+                .withCliOption("-Dtrino.plugin.compressed=true")
+                .execute("package")
+                .assertErrorFreeLog();
+
+        assertThat(bundleEntryMethods(basedir, "basic")).containsOnly(ZipEntry.DEFLATED);
+    }
+
+    private static List<Integer> bundleEntryMethods(File basedir, String projectId)
+            throws IOException
+    {
+        Path pluginZipFile = basedir.toPath().resolve(format("target/%s-1.0.zip", projectId));
+        try (ZipFile zip = new ZipFile(pluginZipFile.toFile())) {
+            return list(zip.entries()).stream().map(ZipEntry::getMethod).toList();
+        }
     }
 
     private static void deleteRecursively(Path directory)


### PR DESCRIPTION
## Motivation

The rewrite to a programmatic model fixed the bundle to `STORED`, on the reasoning that the bundled jars are already compressed archives. That is only mostly right: deflating still recovers the parts that are not, namely their central directories, `META-INF` text and any entries the jar itself stored verbatim.

Measured on `trino-postgresql`:

| build | method | entries | uncompressed | on disk |
|---|---|---|---|---|
| 482 (provisio) | Deflated | 80 | 20.1 MB | 17.9 MB |
| 484-SNAPSHOT | Stored | 88 | 23.5 MB | 23.5 MB |

So roughly a tenth of the bundle, or ~2 MB per plugin. Whether that is worth the compression time on every build depends on the consumer, hence a parameter rather than a new fixed choice.

## Change

Adds a `compress` parameter, settable as `trino.plugin.compressed`:

```xml
<configuration>
    <compress>true</compress>
</configuration>
```

`storedEntry` becomes `bundleEntry` and branches on it. A `DEFLATED` entry needs no header work, since `ZipOutputStream` sizes and checksums it as the data streams through; only the `STORED` path still pre-computes size and CRC, and pays the extra read of each file to do so.

**`STORED` stays the default, so no existing build changes behavior.**

## Testing

Adds two integration tests asserting the entry method in each mode.

Note that I could not execute them locally: the takari harness fails to provision a Maven 3.9.14 runtime in my environment, and does so identically on a clean `master` (`Could not determine Maven version`), so this is pre-existing and unrelated. They need a CI run before being trusted.

Verified by hand instead, packaging the `basic` test project against a locally installed snapshot:

| setting | entries |
|---|---|
| default | `Stored` — 0% |
| `-Dtrino.plugin.compressed=true` | `Defl:N` — 43% / 41% |
| `-Dtrino.plugin.compressed=false` | `Stored` — 0% |

`unzip -t` passes in all three, which exercises the hand-computed CRCs on the `STORED` path.